### PR TITLE
Add license, Windows setup guide, and GitHub link

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) 2025 Nikita Koselev
+
+This work is licensed under the Creative Commons Attribution-NonCommercial 4.0 International License.
+
+You are free to share and adapt the material for noncommercial purposes, provided you give appropriate credit and indicate if changes were made.
+
+Commercial use requires a separate license from the author.
+
+For the full legal text of the license, see https://creativecommons.org/licenses/by-nc/4.0/legalcode.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Tech Edge Intrapreneur Blog
+
+This repository contains the source code for the Tech Edge Intrapreneur blog powered by [Jekyll](https://jekyllrb.com/) and GitHub Pages.
+
+## Running locally on Windows
+
+The recommended way to run the site locally on a Windows machine is to use the [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/windows/wsl/).
+
+1. Install WSL and a Linux distribution (Ubuntu is recommended).
+2. Install Ruby and Bundler:
+   ```bash
+   sudo apt update
+   sudo apt install ruby-full build-essential zlib1g-dev
+   gem install bundler
+   ```
+3. Clone the repository and enter it:
+   ```bash
+   git clone https://github.com/nikitakoselev/nikitakoselev.github.io.git
+   cd nikitakoselev.github.io
+   ```
+4. Install dependencies into a local path to keep them isolated:
+   ```bash
+   bundle install --path vendor/bundle
+   ```
+5. Build and serve the site:
+   ```bash
+   bundle exec jekyll serve
+   ```
+6. Open [http://localhost:4000](http://localhost:4000) in your browser to view the blog.
+
+The site will rebuild automatically as you edit files.
+
+For other Windows setups, you can use [RubyInstaller](https://rubyinstaller.org/) and run the same `bundle` and `jekyll` commands in a command prompt with Ruby available.
+
+## License
+
+[Creative Commons Attribution-NonCommercial 4.0 International](LICENSE)

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,5 +23,8 @@
     <p style="margin-top: 0.5em;">
       💌 Want updates? Subscribe via <a href="/feed.xml">RSS</a>
     </p>
+    <p style="margin-top: 0.5em;">
+      View this site's source on <a href="https://github.com/nikitakoselev/nikitakoselev.github.io" target="_blank">GitHub</a>
+    </p>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
- add Creative Commons BY-NC 4.0 license to restrict commercial use
- document Windows setup steps for running the site locally
- link to this repository from the site's footer

## Testing
- `bundle install`
- `bundle exec jekyll build -d _site_test`


------
https://chatgpt.com/codex/tasks/task_e_68a1dffc1a908320aadc9127965e0033