### PR TITLE
Improve navigation and clean up PulseWriter post

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.11" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_24" project-jdk-name="openjdk-24" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/nikitakoselev.github.io.iml
+++ b/.idea/nikitakoselev.github.io.iml
@@ -2,7 +2,9 @@
 <module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+How to run blog on a windows machine
+
+wsl
+->
+(if not added earlier) add aliases
+alias startblog='rsync -avh --delete /mnt/c/Users/kosel/dev/github/nikitakoselev.github.io/ ~/blog/ && cd ~/blog && bundle exec jekyll serve'
+alias syncblog='rsync -avh --delete /mnt/c/Users/kosel/dev/github/nikitakoselev.github.io/ ~/blog/'
+->
+startblog

--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,6 @@ url: "https://nikitakoselev.github.io"
 theme: minima
 plugins:
   - jekyll-feed
+exclude:
+  - assets/markdown
+excerpt_separator: "<!--more-->"

--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,4 @@ url: "https://nikitakoselev.github.io"
 theme: minima
 plugins:
   - jekyll-feed
-exclude:
-  - assets/markdown
 excerpt_separator: "<!--more-->"

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,5 +1,5 @@
 ---
-layout: base
+layout: default
 ---
 <article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,6 +4,7 @@ layout: base
 <article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
 
   <header class="post-header">
+    <nav class="post-breadcrumb"><a href="{{ '/' | relative_url }}">&larr; Home</a></nav>
     <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
     <div class="post-meta">
       {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
@@ -47,14 +48,13 @@ layout: base
   {% endif -%}
 
   <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
-  <div style="margin-top:2em; padding-top:1em; border-top:1px solid #eee;">
-  <p>If this post helped you or inspired you, consider supporting my work:</p>
-  <a href="https://github.com/sponsors/nikitakoselev" target="_blank">
-    <img src="https://img.shields.io/badge/Sponsor%20on-GitHub-black?logo=github" alt="Sponsor on GitHub" />
-  </a>
-  <a href="https://buymeacoffee.com/2o3yfdbjpo" target="_blank" style="margin-left:10px;">
-    <img src="https://img.shields.io/badge/Buy%20me%20a-Coffee-ffdd00?logo=buymeacoffee&logoColor=000" alt="Buy me a coffee" />
-  </a>
-</div>
+  <div class="support-links" style="margin-top:2em; padding-top:1em; border-top:1px solid #eee;">
+    <p>If this post helped you, consider supporting my work:</p>
+    <p>
+      <a href="https://github.com/sponsors/nikitakoselev" target="_blank">💖 Sponsor on GitHub</a>
+      ·
+      <a href="https://buymeacoffee.com/2o3yfdbjpo" target="_blank">☕ Buy me a coffee</a>
+    </p>
+  </div>
 
 </article>

--- a/_posts/2025-08-17-pulsewriter-life-transformation.md
+++ b/_posts/2025-08-17-pulsewriter-life-transformation.md
@@ -5,104 +5,109 @@ date: 2025-08-17
 categories: [open-source, business-transformation, ai, automation]
 ---
 
-💡 *If this story resonates, you can support my journey through [GitHub Sponsors](https://github.com/sponsors/nikitakoselev). Even $1/month helps me keep exploring how open-source tools can improve my life and those around me — and sharing them so they can improve yours too. A one-time coffee is also deeply appreciated: [buymeacoffee.com/2o3yfdbjpo](https://buymeacoffee.com/2o3yfdbjpo).*  
+PulseWriter is my "write once, publish everywhere" experiment—small, fast, and aligned with my values of **Health** and **Family**. Here's how it came to life and why it matters.
+
+<!--more-->
+
+> 🙌 **Support the Journey**  
+> Sponsor me on [GitHub](https://github.com/sponsors/nikitakoselev) or buy me a ☕ on [Buy Me a Coffee](https://buymeacoffee.com/2o3yfdbjpo).
 
 ---
 
-## A bigger life transformation
+## A bigger life transformation 🌱
 
-For me, **business transformation** isn’t just a buzzword — it’s become the lens through which I live.  
+For me, **business transformation** isn’t just a buzzword — it’s become the lens through which I live.
 
-I root everything in two values:  
+I root everything in two values:
 
-- **Health** — physical, financial, mental, educational. If I collapse in one area, I lose the power to act.  
-- **Family** — my close family first, but also humanity as a whole. The way to serve is to start by “cleaning my own room”: taking microsteps that strengthen my health, which then ripple outward.  
+- **Health 🧠💪** — physical, financial, mental, educational. If I collapse in one area, I lose the power to act.
+- **Family 👨‍👩‍👦** — my close family first, but also humanity as a whole. The way to serve is to start by “cleaning my own room”: taking microsteps that strengthen my health, which then ripple outward.
 
-From these values flow my goals:  
-- **Operational**: daily actions that keep me strong and balanced.  
-- **Tactical**: building tools that free time and mental energy.  
-- **Strategic**: creating systems (income flows, automation, open source) that sustain my family and contribute to the wider human family.  
-
----
-
-## Why PulseWriter?
-
-This philosophy led me to a simple frustration:  
-I wanted to share my thoughts online. But every platform — blog, LinkedIn, X, Dev.to — demanded a different format. Copy-pasting was not just boring, it was draining.  
-
-So I asked: *what if I could write once, and let a tool transform it for me?*  
-
-That became **PulseWriter**: my “write once, publish everywhere” experiment. Not a Markdown slicer — but a tool that uses **AI and prompt libraries to craft drafts suited to each platform**.  
+From these values flow my goals:
+- **Operational**: daily actions that keep me strong and balanced.
+- **Tactical**: building tools that free time and mental energy.
+- **Strategic**: creating systems (income flows, automation, open source) that sustain my family and contribute to the wider human family.
 
 ---
 
-## How I built it (from a sofa)
+## Why PulseWriter? 🚀
 
-The first attempt was messy: broken imports, missing modules, a README pointing to a non-existent command.  
+This philosophy led me to a simple frustration:
+I wanted to share my thoughts online. But every platform — blog, LinkedIn, X, Dev.to — demanded a different format. Copy-pasting was not just boring, it was draining.
 
-But with help from today’s tools, it came together quickly:  
-- **Codex** and **ChatGPT** for debugging and fixes.  
-- **VS Code** and **GitHub Copilot** for rapid coding.  
-- **IntelliJ IDEA** for day-to-day (sorry Microsoft — but as a Java engineer doing a Python project, IntelliJ feels natural).  
+So I asked: *what if I could write once, and let a tool transform it for me?*
 
-And the kicker: I built it in just a few hours, lying on a sofa at my parents’ place, on an old **Microsoft Surface Go 3**. No desk. No big setup. Just stubbornness and focus.  
+That became **PulseWriter**: my “write once, publish everywhere” experiment. Not a Markdown slicer — but a tool that uses **AI and prompt libraries to craft drafts suited to each platform**.
 
-Within hours, PulseWriter went from broken to working:  
+---
+
+## How I built it (from a sofa) 🛋️
+
+The first attempt was messy: broken imports, missing modules, a README pointing to a non-existent command.
+
+But with help from today’s tools, it came together quickly:
+- **Codex** and **ChatGPT** for debugging and fixes.
+- **VS Code** and **GitHub Copilot** for rapid coding.
+- **IntelliJ IDEA** for day-to-day (sorry Microsoft — but as a Java engineer doing a Python project, IntelliJ feels natural).
+
+And the kicker: I built it in just a few hours, lying on a sofa at my parents’ place, on an old **Microsoft Surface Go 3**. No desk. No big setup. Just stubbornness and focus.
+
+Within hours, PulseWriter went from broken to working:
 
 ```bash
 pulsewriter transform post.md --platforms blog linkedin x devto --out-dir out
 ```
 
-And out came four drafts — one for each platform.  
+And out came four drafts — one for each platform.
 
-![Terminal output showing PulseWriter run](../assets/images/62895882-076f-4f4c-9694-c972bbde40d4.png)  
-*First successful run in IntelliJ’s terminal.*  
+![Terminal output showing PulseWriter run](../assets/images/62895882-076f-4f4c-9694-c972bbde40d4.png)
+*First successful run in IntelliJ’s terminal.*
 
-![All output files open](../assets/images/84b6717a-a9b6-4674-80ea-4dee7af5d001.png)  
-*The generated drafts — Blog, LinkedIn, X, Dev.to — all open side-by-side.*  
-
----
-
-## What it does today
-
-Right now PulseWriter:  
-- Reads a single Markdown file.  
-- Generates drafts for Blog, LinkedIn, X, Dev.to using Jinja2 templates.  
-- Saves hours of repetitive formatting.  
-
-Here are the first outputs it produced:  
-- [Blog draft](../assets/markdown/pulsewriter.blog_md.md)  
-- [LinkedIn draft](../assets/markdown/pulsewriter.linkedin_md.md)  
-- [Dev.to draft](../assets/markdown/pulsewriter.devto_md.md)  
-- [X draft](../assets/text/pulsewriter.x_thread.txt)  
-
-The X version still needs work — but it’s a start. The magic is seeing one idea flow instantly into multiple formats.  
+![All output files open](../assets/images/84b6717a-a9b6-4674-80ea-4dee7af5d001.png)
+*The generated drafts — Blog, LinkedIn, X, Dev.to — all open side-by-side.*
 
 ---
 
-## Where it’s going
+## What it does today ✨
 
-This is just step one.  
+Right now PulseWriter:
+- Reads a single Markdown file.
+- Generates drafts for Blog, LinkedIn, X, Dev.to using Jinja2 templates.
+- Saves hours of repetitive formatting.
 
-The vision is for PulseWriter to:  
-- Use **AI + prompt libraries** to tailor outputs, not just slice text.  
-- Adapt prompts based on my reactions (with another open-source tool I’m planning).  
-- Tie into **n8n** workflows so drafts don’t just get generated, but also published.  
-- Explore tools like **Tessl** to map feature lists and generate the products I need for myself, my family, and humanity.  
+Here are the first outputs it produced:
+- 📝 [Blog draft](https://raw.githubusercontent.com/nikitakoselev/nikitakoselev.github.io/main/assets/markdown/pulsewriter.blog_md.md)
+- 💼 [LinkedIn draft](https://raw.githubusercontent.com/nikitakoselev/nikitakoselev.github.io/main/assets/markdown/pulsewriter.linkedin_md.md)
+- 🌐 [Dev.to draft](https://raw.githubusercontent.com/nikitakoselev/nikitakoselev.github.io/main/assets/markdown/pulsewriter.devto_md.md)
+- 🐦 [X draft](https://raw.githubusercontent.com/nikitakoselev/nikitakoselev.github.io/main/assets/text/pulsewriter.x_thread.txt)
 
-PulseWriter will grow. But the deeper transformation is already here:  
-> Each microstep makes me healthier, more focused, and more able to contribute to my close and extended family.  
-
----
-
-## Closing thought
-
-Business transformation doesn’t have to start in a boardroom. It can start with one person, two values, a sofa, an old Surface Go 3 — and the decision to fix a messy repo.  
-
-Even one person can treat every microstep as quality business — creating value, growing health, and making the world a bit better.  
+The X version still needs work — but it’s a start. The magic is seeing one idea flow instantly into multiple formats.
 
 ---
 
-👉 Code: [github.com/nikitakoselev](https://github.com/nikitakoselev)  
-👉 Blog: [nikitakoselev.github.io](https://nikitakoselev.github.io/)  
-👉 Support: [GitHub Sponsors](https://github.com/sponsors/nikitakoselev) · [Buy Me a Coffee](https://buymeacoffee.com/2o3yfdbjpo)  
+## Where it’s going 🔭
+
+This is just step one.
+
+The vision is for PulseWriter to:
+- Use **AI + prompt libraries** to tailor outputs, not just slice text.
+- Adapt prompts based on my reactions (with another open-source tool I’m planning).
+- Tie into **n8n** workflows so drafts don’t just get generated, but also published.
+- Explore tools like **Tessl** to map feature lists and generate the products I need for myself, my family, and humanity.
+
+PulseWriter will grow. But the deeper transformation is already here:
+> Each microstep makes me healthier, more focused, and more able to contribute to my close and extended family.
+
+---
+
+## Closing thought 💭
+
+Business transformation doesn’t have to start in a boardroom. It can start with one person, two values, a sofa, an old Surface Go 3 — and the decision to fix a messy repo.
+
+Even one person can treat every microstep as quality business — creating value, growing health, and making the world a bit better.
+
+---
+
+👉 Code: [github.com/nikitakoselev](https://github.com/nikitakoselev)
+👉 Blog: [nikitakoselev.github.io](https://nikitakoselev.github.io/)
+👉 Support: [GitHub Sponsors](https://github.com/sponsors/nikitakoselev) · [Buy Me a Coffee](https://buymeacoffee.com/2o3yfdbjpo)

--- a/_posts/2025-08-17-pulsewriter-life-transformation.md
+++ b/_posts/2025-08-17-pulsewriter-life-transformation.md
@@ -60,10 +60,10 @@ pulsewriter transform post.md --platforms blog linkedin x devto --out-dir out
 
 And out came four drafts — one for each platform.
 
-![Terminal output showing PulseWriter run](../assets/images/62895882-076f-4f4c-9694-c972bbde40d4.png)
+![Terminal output showing PulseWriter run](/assets/images/62895882-076f-4f4c-9694-c972bbde40d4.png)
 *First successful run in IntelliJ’s terminal.*
 
-![All output files open](../assets/images/84b6717a-a9b6-4674-80ea-4dee7af5d001.png)
+![All output files open](/assets/images/84b6717a-a9b6-4674-80ea-4dee7af5d001.png)
 *The generated drafts — Blog, LinkedIn, X, Dev.to — all open side-by-side.*
 
 ---
@@ -76,10 +76,9 @@ Right now PulseWriter:
 - Saves hours of repetitive formatting.
 
 Here are the first outputs it produced:
-- 📝 [Blog draft](https://raw.githubusercontent.com/nikitakoselev/nikitakoselev.github.io/main/assets/markdown/pulsewriter.blog_md.md)
-- 💼 [LinkedIn draft](https://raw.githubusercontent.com/nikitakoselev/nikitakoselev.github.io/main/assets/markdown/pulsewriter.linkedin_md.md)
-- 🌐 [Dev.to draft](https://raw.githubusercontent.com/nikitakoselev/nikitakoselev.github.io/main/assets/markdown/pulsewriter.devto_md.md)
-- 🐦 [X draft](https://raw.githubusercontent.com/nikitakoselev/nikitakoselev.github.io/main/assets/text/pulsewriter.x_thread.txt)
+- 📝 [Blog draft](/assets/markdown/pulsewriter.blog_md.md)
+- 💼 [LinkedIn draft](/assets/markdown/pulsewriter.linkedin_md.md)
+- 🌐 [Dev.to draft](/assets/markdown/pulsewriter.devto_md.md)
 
 The X version still needs work — but it’s a start. The magic is seeing one idea flow instantly into multiple formats.
 


### PR DESCRIPTION
## Summary
- add breadcrumb link and streamlined support section on posts
- configure Jekyll to skip raw markdown drafts and use a custom excerpt break
- polish PulseWriter article with icons, callouts and cleaned draft links

## Testing
- `bundle exec jekyll build --future`

------
https://chatgpt.com/codex/tasks/task_e_68a1ff25f1b48320b348416ce111848a